### PR TITLE
TargetIndicator: prevent zero division

### DIFF
--- a/Assets/Scripts/TargetIndicator.cs
+++ b/Assets/Scripts/TargetIndicator.cs
@@ -117,13 +117,10 @@ public class TargetIndicator : MonoBehaviour
     {
         Vector3 returnVector = vector;
 
-        float max = 0;
-
-        max = vector.x > max ? vector.x : max;
-        max = vector.y > max ? vector.y : max;
-        max = vector.z > max ? vector.z : max;
-
-        returnVector /= max;
+        float max = Mathf.Max(vector.x, vector.y, 0f);
+        if (max != 0f) {
+            returnVector /= max;
+        }
 
         return returnVector;
     }


### PR DESCRIPTION
Hi,
found this script shared somewhere in Unity forums, and it was quite helpful, so here's a tiny fix: in case `max` value is zero, it will skip the division.

Plus a microoptimization - this function is called only in case `vector.z` is lower than zero, so its value doesnt need to be taken into accont when calculating `max`.